### PR TITLE
improve postcode range for en_US -> TX

### DIFF
--- a/lib/locales/en_US/address/postcode_by_state.js
+++ b/lib/locales/en_US/address/postcode_by_state.js
@@ -176,8 +176,8 @@ module["exports"] = {
     max:38589
   },
   TX:{
-    min:73301,
-    max:73301
+    min:75503,
+    max:79999
   },
   UT:{
     min:84001,


### PR DESCRIPTION
The original range would only ever result in 1 value (73301)
New range taken from here: http://www.structnet.com/instructions/zip_min_max_by_state.html